### PR TITLE
Optimization and Refactoring of Death Inventory Log Commands

### DIFF
--- a/resources/db/local_uuid_gamertag_translator.sql
+++ b/resources/db/local_uuid_gamertag_translator.sql
@@ -3,25 +3,25 @@
 
 -- #  { init_translator
 CREATE TABLE IF NOT EXISTS death_inventory_log_uuid_gamertag(
-  uuid BINARY(16) NOT NULL PRIMARY KEY,
+  player_uuid BINARY(16) NOT NULL PRIMARY KEY,
   gamertag VARCHAR(16) NOT NULL
 );
 -- #  }
 
 -- #  { translate_uuids
 -- #    :uuids string
-SELECT uuid, gamertag FROM death_inventory_log_uuid_gamertag WHERE uuid IN (:uuids);
+SELECT player_uuid, gamertag FROM death_inventory_log_uuid_gamertag WHERE player_uuid IN (:uuids);
 -- #  }
 
 -- #  { translate_gamertags
 -- #    :gamertags string
-SELECT uuid, gamertag FROM death_inventory_log_uuid_gamertag WHERE LOWER(gamertag) IN (:gamertags);
+SELECT player_uuid, gamertag FROM death_inventory_log_uuid_gamertag WHERE LOWER(gamertag) IN (:gamertags);
 -- #  }
 
 -- #  { store_translation
--- #    :uuid string
+-- #    :player_uuid string
 -- #    :gamertag string
-INSERT OR REPLACE INTO death_inventory_log_uuid_gamertag(uuid, gamertag) VALUES(:uuid, :gamertag);
+INSERT OR REPLACE INTO death_inventory_log_uuid_gamertag(player_uuid, gamertag) VALUES(:player_uuid, :gamertag);
 -- #  }
 
 -- #}

--- a/resources/db/mysql.sql
+++ b/resources/db/mysql.sql
@@ -1,52 +1,49 @@
 -- #!mysql
+
 -- #{ deathinventorylog
 
 -- #  { init
 -- #    { create_table
-CREATE TABLE IF NOT EXISTS death_inventory_log(
-  id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
-  uuid BINARY(16) NOT NULL,
-  time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP(),
-  inventory BLOB NOT NULL,
-  armor_inventory BLOB NOT NULL,
-  offhand_inventory BLOB NOT NULL,
-  KEY uuid_idx(uuid)
-);
--- #    }
--- #    { index_uuid
-ALTER TABLE death_inventory_log ADD INDEX uuid_idx(uuid);
+CREATE TABLE IF NOT EXISTS death_inventory_log (
+                                                   id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+                                                   player_uuid BINARY(16) NOT NULL,
+                                                   log_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+                                                   item_inventory BLOB NOT NULL,
+                                                   armor_inventory BLOB NOT NULL,
+                                                   offhand_inventory BLOB NOT NULL,
+                                                   KEY uuid_time_idx(player_uuid, log_time)
+    );
 -- #    }
 -- #  }
-
 -- #  { retrieve
 -- #    :id int
-SELECT id, uuid, UNIX_TIMESTAMP(time) AS time, inventory, armor_inventory, offhand_inventory FROM death_inventory_log WHERE id=:id;
+SELECT id, player_uuid, UNIX_TIMESTAMP(log_time) AS log_time, item_inventory, armor_inventory, offhand_inventory FROM death_inventory_log WHERE id = :id;
 -- #  }
 
 -- #  { retrieve_player
--- #    :uuid string
+-- #    :player_uuid string
 -- #    :offset int
 -- #    :length int
-SELECT id, uuid, UNIX_TIMESTAMP(time) AS time, inventory, armor_inventory, offhand_inventory FROM death_inventory_log WHERE uuid=:uuid ORDER BY id DESC LIMIT :offset, :length;
+SELECT id, player_uuid, UNIX_TIMESTAMP(log_time) AS log_time, item_inventory, armor_inventory, offhand_inventory FROM death_inventory_log WHERE player_uuid = :player_uuid ORDER BY id DESC LIMIT :offset, :length;
 -- #  }
 
 -- #  { save
--- #    :uuid string
--- #    :inventory string
+-- #    :player_uuid string
+-- #    :item_inventory string
 -- #    :armor_inventory string
 -- #    :offhand_inventory string
-INSERT INTO death_inventory_log(uuid, inventory, armor_inventory, offhand_inventory) VALUES(FROM_BASE64(:uuid), FROM_BASE64(:inventory), FROM_BASE64(:armor_inventory), FROM_BASE64(:offhand_inventory));
+INSERT INTO death_inventory_log(player_uuid, item_inventory, armor_inventory, offhand_inventory) VALUES(FROM_BASE64(:player_uuid), FROM_BASE64(:item_inventory), FROM_BASE64(:armor_inventory), FROM_BASE64(:offhand_inventory));
 -- #  }
 
 -- #  { purge
--- #    :time int
-DELETE FROM death_inventory_log WHERE time <= FROM_UNIXTIME(:time);
+-- #    :log_time int
+DELETE FROM death_inventory_log WHERE log_time <= FROM_UNIXTIME(:log_time);
 -- #  }
 
 -- #  { upgrade
 -- #    { impl_offhand_inventory
-ALTER TABLE death_inventory_log ADD COLUMN offhand_inventory BLOB DEFAULT "";
-ALTER TABLE death_inventory_log ADD COLUMN offhand_inventory BLOB NOT NULL;
+-- ALTER TABLE death_inventory_log ADD COLUMN offhand_inventory BLOB DEFAULT "";
+-- Elimina la línea anterior si solo necesitas una columna offhand_inventory.
 -- #    }
 -- #  }
 -- #}

--- a/src/muqsit/deathinventorylog/Loader.php
+++ b/src/muqsit/deathinventorylog/Loader.php
@@ -25,6 +25,7 @@ use pocketmine\inventory\ArmorInventory;
 use pocketmine\item\VanillaItems;
 use pocketmine\player\Player;
 use pocketmine\plugin\PluginBase;
+use pocketmine\Server;
 use pocketmine\utils\TextFormat;
 use pocketmine\utils\VersionString;
 use Ramsey\Uuid\Uuid;
@@ -119,98 +120,184 @@ final class Loader extends PluginBase{
 		return $this->database;
 	}
 
-	public function onCommand(CommandSender $sender, Command $command, string $label, array $args) : bool{
-		if(isset($args[0])){
-			switch($args[0]){
-				case "history":
-					if(!isset($args[1])){
-						$sender->sendMessage(TextFormat::RED . "/{$label} {$args[0]} <player> [page=1]");
-						return true;
-					}
+    public function onCommand(CommandSender $sender, Command $command, string $label, array $args): bool
+    {
+        if (isset($args[0])) {
+            switch ($args[0]) {
+                case "history":
+                    if (!isset($args[1])) {
+                        $sender->sendMessage(TextFormat::RED . "/{$label} {$args[0]} <player> [page=1]");
+                        return true;
+                    }
 
-					$page = isset($args[2]) ? max(1, (int) $args[2]) : 1;
-					$gamertags = [$args[1]];
-					Await::f2c(function() use($page, $sender, $gamertags) : Generator{
-						static $per_page = 10;
-						$offset = ($page - 1) * $per_page;
-						$translation = current(yield from Await::promise(function(Closure $resolve) use($gamertags) : void{
-							$this->getTranslator()->translateGamertags($gamertags, $resolve);
-						}));
-						$entries = $translation !== false ? yield from Await::promise(function(Closure $resolve) use($offset, $per_page, $translation) : void{
-							$this->database->retrievePlayer(Uuid::fromBytes($translation), $offset, $per_page, $resolve);
-						}) : [];
+                    $page = max(1, isset($args[2]) ? (int)$args[2] : 1);
+                    $gamertags = [$args[1]];
 
-						/** @var DeathInventoryLog[] $entries */
-						if(count($entries) === 0){
-							$sender->sendMessage($page === 1 ? TextFormat::RED . "No logs found for that player." : TextFormat::RED . "No logs found on page {$page} for that player.");
-							return;
-						}
+                    Await::f2c(function() use($page, $sender, $gamertags) : Generator {
+                        $per_page = 10;
+                        $offset = ($page - 1) * $per_page;
 
-						if($sender instanceof Player && !$sender->isConnected()){
-							return;
-						}
+                        $translation = yield from Await::promise(function(Closure $resolve) use($gamertags) : void {
+                            $this->getTranslator()->translateGamertags($gamertags, $resolve);
+                        });
 
-						$message = TextFormat::BOLD . TextFormat::RED . "Death Entries Page {$page}" . TextFormat::RESET . TextFormat::EOL;
-						foreach($entries as $entry){
-							$message .= TextFormat::BOLD . TextFormat::RED . ++$offset . ". " . TextFormat::RESET . TextFormat::WHITE . "#{$entry->id} " . TextFormat::GRAY . "logged on " . gmdate("Y-m-d h:i:s", $entry->timestamp) . TextFormat::EOL;
-						}
-						$sender->sendMessage($message);
-					});
-					return true;
-				case "retrieve":
-					if(!($sender instanceof Player)){
-						$sender->sendMessage(TextFormat::RED . "This command can only be executed in-game.");
-						return true;
-					}
+                        if (empty($translation))
+                        {
+                            $sender->sendMessage("no results");
+                            return false;
+                        }
+                        $entries = yield from Await::promise(function(Closure $resolve) use($offset, $per_page, $translation, $gamertags) : void {
+                            $this->database->retrievePlayer(Uuid::fromBytes($translation[strtolower($gamertags[0])]), $offset, $per_page, $resolve);
+                        });
 
-					if(!isset($args[1])){
-						$sender->sendMessage(TextFormat::RED . "/{$label} {$args[0]} <id>");
-						return true;
-					}
+                        if(count($entries) === 0){
+                            $sender->sendMessage($page === 1 ? TextFormat::RED . "No logs found for that player." : TextFormat::RED . "No logs found on page {$page} for that player.");
+                            return false;
+                        }
 
-					$id = (int) $args[1];
-					$this->database->retrieve($id, static function(?DeathInventoryLog $log) use ($sender, $id) : void{
-						if(!$sender->isConnected()){
-							return;
-						}
+                        if($sender instanceof Player && !$sender->isConnected()){
+                            return false;
+                        }
 
-						if($log === null){
-							$sender->sendMessage(TextFormat::RED . "No death log with the id #{$id} could be found.");
-							return;
-						}
+                        $message = TextFormat::BOLD . TextFormat::RED . "Death Entries Page {$page}" . TextFormat::RESET . TextFormat::EOL;
+                        foreach($entries as $entry){
+                            $message .= TextFormat::BOLD . TextFormat::RED . ++$offset . ". " . TextFormat::RESET . TextFormat::WHITE . "#{$entry->id} " . TextFormat::GRAY . "logged on " . gmdate("Y-m-d h:i:s", $entry->timestamp) . TextFormat::EOL;
+                        }
+                        $sender->sendMessage($message);
+                    });
+                    return true;
+                case "restore":
+                    return $this->executeRestoreCommand($sender, $label, $args);
 
-						$sender->sendMessage(TextFormat::GRAY . "Retrieved death inventory log #{$log->id}");
+                case "view":
+                    return $this->executeViewCommand($sender,$label, $args);
+            }
+        }
 
-						$items = $log->inventory->inventory_contents;
+        $sender->sendMessage(
+            TextFormat::BOLD . TextFormat::RED . "Death Inventory Log Commands" . TextFormat::RESET . TextFormat::EOL .
+            TextFormat::WHITE . "/{$label} history <player> [page=1] " . TextFormat::GRAY . "Retrieve a player's death log history" . TextFormat::EOL .
+            TextFormat::WHITE . "/{$label} restore <player> <id> " . TextFormat::GRAY . "Retrieve inventory contents of a specific death log" . TextFormat::EOL .
+            TextFormat::WHITE . "/{$label} view <id> " . TextFormat::GRAY . "Retrieve inventory contents of a specific death log"
+        );
+        return true;
+    }
 
-						$armor_inventory = $log->inventory->armor_contents;
-						foreach([
-							ArmorInventory::SLOT_HEAD => 47,
-							ArmorInventory::SLOT_CHEST => 48,
-							ArmorInventory::SLOT_LEGS => 50,
-							ArmorInventory::SLOT_FEET => 51
-						] as $armor_inventory_slot => $menu_slot){
-							if(isset($armor_inventory[$armor_inventory_slot])){
-								$items[$menu_slot] = $armor_inventory[$armor_inventory_slot];
-							}
-						}
+    private function executeRestoreCommand(CommandSender $sender,string $label, array $args): bool
+    {
+        if (!($sender instanceof Player)) {
+            $sender->sendMessage(TextFormat::RED . "This command can only be executed in-game.");
+            return true;
+        }
 
-						$items[53] = $log->inventory->offhand_contents[0] ?? VanillaItems::AIR();
+        if (!isset($args[1]) || !isset($args[2]) || !is_numeric($args[2])) {
+            $sender->sendMessage(TextFormat::RED . "/{$label} {$args[0]} <player> <id>");
+            return true;
+        }
 
-						$menu = InvMenu::create(InvMenu::TYPE_DOUBLE_CHEST);
-						$menu->setName("Death Inventory Log #{$log->id}");
-						$menu->getInventory()->setContents($items);
-						$menu->send($sender);
-					});
-					return true;
-			}
-		}
+        $player = Server::getInstance()->getPlayerByPrefix($args[1]);
+        if (!$player instanceof Player) {
+            $sender->sendMessage("§cPlayer offline");
+            return false;
+        }
 
-		$sender->sendMessage(
-			TextFormat::BOLD . TextFormat::RED . "Death Inventory Log Commands" . TextFormat::RESET . TextFormat::EOL .
-			TextFormat::WHITE . "/{$label} history <player> [page=1] " . TextFormat::GRAY . "Retrieve a player's death log history" . TextFormat::EOL .
-			TextFormat::WHITE . "/{$label} retrieve <id> " . TextFormat::GRAY . "Retrieve inventory contents of a specific death log"
-		);
-		return true;
-	}
+        $id = (int)$args[2];
+        $this->retrieveAndApplyLog($id, $sender, $player);
+        return true;
+    }
+
+    private function executeViewCommand(CommandSender $sender, string $label, array $args): bool
+    {
+        if (!($sender instanceof Player)) {
+            $sender->sendMessage(TextFormat::RED . "This command can only be executed in-game.");
+            return true;
+        }
+
+        if (!isset($args[1]) || !is_numeric($args[1])) {
+            $sender->sendMessage(TextFormat::RED . "/{$label} {$args[0]} <id>");
+            return true;
+        }
+
+        $id = (int)$args[1];
+        $this->retrieveAndDisplayLog($id, $sender, $args[0]);
+        return true;
+    }
+
+    private function retrieveAndApplyLog(int $id, CommandSender $sender, Player $player): void
+    {
+        $this->database->retrieve($id, function (?DeathInventoryLog $log) use ($sender, $id, $player): void {
+            if (!$player->isConnected()) {
+                return;
+            }
+
+            if ($log === null) {
+                $sender->sendMessage(TextFormat::RED . "No death log with the id #{$id} could be found.");
+                return;
+            }
+
+            $sender->sendMessage(TextFormat::GRAY . "Retrieved death inventory log #{$log->id} to {$player->getName()}");
+            $this->applyLogToPlayer($log, $player);
+        });
+    }
+
+    private function retrieveAndDisplayLog(int $id, CommandSender $sender, string $command): void
+    {
+        $this->database->retrieve($id, function (?DeathInventoryLog $log) use ($sender, $id, $command): void {
+            if ($log === null) {
+                $sender->sendMessage(TextFormat::RED . "No death log with the id #{$id} could be found.");
+                return;
+            }
+
+            $this->displayLogToSender($log, $sender, $command);
+        });
+    }
+
+    private function applyLogToPlayer(DeathInventoryLog $log, Player $player): void
+    {
+        $items = $log->inventory->inventory_contents;
+        $armor_inventory = $log->inventory->armor_contents;
+
+        foreach ([
+                     ArmorInventory::SLOT_HEAD => 47,
+                     ArmorInventory::SLOT_CHEST => 48,
+                     ArmorInventory::SLOT_LEGS => 50,
+                     ArmorInventory::SLOT_FEET => 51,
+                 ] as $armor_inventory_slot => $menu_slot) {
+            if (isset($armor_inventory[$armor_inventory_slot])) {
+                $items[$menu_slot] = $armor_inventory[$armor_inventory_slot];
+            }
+        }
+
+        $items[53] = $log->inventory->offhand_contents[0] ?? VanillaItems::AIR();
+        $player->getInventory()->setContents($items);
+    }
+
+    private function displayLogToSender(DeathInventoryLog $log, CommandSender $sender, string $command): void
+    {
+        if (!$sender instanceof Player) return;
+        $items = $log->inventory->inventory_contents;
+        $armor_inventory = $log->inventory->armor_contents;
+
+        foreach ([
+                     ArmorInventory::SLOT_HEAD => 47,
+                     ArmorInventory::SLOT_CHEST => 48,
+                     ArmorInventory::SLOT_LEGS => 50,
+                     ArmorInventory::SLOT_FEET => 51,
+                 ] as $armor_inventory_slot => $menu_slot) {
+            if (isset($armor_inventory[$armor_inventory_slot])) {
+                $items[$menu_slot] = $armor_inventory[$armor_inventory_slot];
+            }
+        }
+
+        $items[53] = $log->inventory->offhand_contents[0] ?? VanillaItems::AIR();
+
+        if ($command === "view") {
+            $menu = InvMenu::create(InvMenu::TYPE_DOUBLE_CHEST);
+            $menu->setName("Death Inventory Log #{$log->id}");
+            $menu->getInventory()->setContents($items);
+            $menu->send($sender);
+        }
+    }
+
+
 }

--- a/src/muqsit/deathinventorylog/db/MySQLDatabase.php
+++ b/src/muqsit/deathinventorylog/db/MySQLDatabase.php
@@ -37,13 +37,6 @@ final class MySQLDatabase implements Database{
 			]
 		], ["mysql" => "db/mysql.sql"]);
 		$connector->executeGeneric("deathinventorylog.init.create_table");
-		$connector->executeGeneric("deathinventorylog.init.index_uuid", [], null, static function(SqlError $error) : void{
-			if($error->getMessage() === "SQL EXECUTION error: Duplicate key name 'uuid_idx', for query ALTER TABLE death_inventory_log ADD INDEX uuid_idx(uuid); | []"){
-				// TODO: compare error message against an SQL error code instead (SqlError::getCode() seems to always return 0 here)
-				return;
-			}
-			throw $error;
-		});
 		$connector->waitAll();
 		return new self($connector);
 	}
@@ -69,8 +62,8 @@ final class MySQLDatabase implements Database{
 
 	public function store(UuidInterface $player, DeathInventory $inventory, Closure $callback) : void{
 		$this->connector->executeInsert("deathinventorylog.save", [
-			"uuid" => base64_encode($player->getBytes()),
-			"inventory" => base64_encode(InventorySerializer::serialize($inventory->inventory_contents)),
+			"player_uuid" => base64_encode($player->getBytes()),
+			"item_inventory" => base64_encode(InventorySerializer::serialize($inventory->inventory_contents)),
 			"armor_inventory" => base64_encode(InventorySerializer::serialize($inventory->armor_contents)),
 			"offhand_inventory" => base64_encode(InventorySerializer::serialize($inventory->offhand_contents))
 		], static function(int $insert_id, int $affected_rows) use($callback) : void{ $callback($insert_id); }, $this->handleError());
@@ -82,13 +75,13 @@ final class MySQLDatabase implements Database{
 			if($row !== false){
 				$callback(new DeathInventoryLog(
 					$row["id"],
-					Uuid::fromBytes($row["uuid"]),
+					Uuid::fromBytes($row["player_uuid"]),
 					new DeathInventory(
-						InventorySerializer::deSerialize($row["inventory"]),
+						InventorySerializer::deSerialize($row["item_inventory"]),
 						InventorySerializer::deSerialize($row["armor_inventory"]),
 						InventorySerializer::deSerialize($row["offhand_inventory"])
 					),
-					$row["time"]
+					$row["log_time"]
 				));
 			}else{
 				$callback(null);
@@ -98,7 +91,7 @@ final class MySQLDatabase implements Database{
 
 	public function retrievePlayer(UuidInterface $player, int $offset, int $length, Closure $callback) : void{
 		$this->connector->executeSelect("deathinventorylog.retrieve_player", [
-			"uuid" => $player->getBytes(),
+			"player_uuid" => $player->getBytes(),
 			"offset" => $offset,
 			"length" => $length
 		], static function(array $rows) use($callback) : void{
@@ -106,13 +99,13 @@ final class MySQLDatabase implements Database{
 			foreach($rows as $row){
 				$result[] = new DeathInventoryLog(
 					$row["id"],
-					Uuid::fromBytes($row["uuid"]),
+					Uuid::fromBytes($row["player_uuid"]),
 					new DeathInventory(
-						InventorySerializer::deSerialize($row["inventory"]),
+						InventorySerializer::deSerialize($row["item_inventory"]),
 						InventorySerializer::deSerialize($row["armor_inventory"]),
 						InventorySerializer::deSerialize($row["offhand_inventory"])
 					),
-					$row["time"]
+					$row["log_time"]
 				);
 			}
 			$callback($result);
@@ -120,7 +113,7 @@ final class MySQLDatabase implements Database{
 	}
 
 	public function purge(int $older_than_timestamp, Closure $callback) : void{
-		$this->connector->executeChange("deathinventorylog.purge", ["time" => $older_than_timestamp], static function(int $affectedRows) use($callback) : void{
+		$this->connector->executeChange("deathinventorylog.purge", ["log_time" => $older_than_timestamp], static function(int $affectedRows) use($callback) : void{
 			$callback($affectedRows);
 		}, $this->handleError());
 	}

--- a/src/muqsit/deathinventorylog/translator/LocalGamertagUUIDTranslator.php
+++ b/src/muqsit/deathinventorylog/translator/LocalGamertagUUIDTranslator.php
@@ -29,7 +29,7 @@ final class LocalGamertagUUIDTranslator implements GamertagUUIDTranslator{
 
 	public function store(UuidInterface $uuid, string $gamertag) : void{
 		$this->connector->executeInsert("deathinventorylog.store_translation", [
-			"uuid" => $uuid->toString(),
+			"player_uuid" => $uuid->toString(),
 			"gamertag" => $gamertag
 		]);
 	}
@@ -40,7 +40,7 @@ final class LocalGamertagUUIDTranslator implements GamertagUUIDTranslator{
 		], static function(array $rows) use($callback) : void{
 			$result = [];
 			foreach($rows as $row){
-				$result[Uuid::fromString($row["uuid"])->getBytes()] = $row["gamertag"];
+				$result[Uuid::fromString($row["player_uuid"])->getBytes()] = $row["gamertag"];
 			}
 			$callback($result);
 		});
@@ -52,7 +52,7 @@ final class LocalGamertagUUIDTranslator implements GamertagUUIDTranslator{
 		], static function(array $rows) use($callback) : void{
 			$result = [];
 			foreach($rows as $row){
-				$result[strtolower($row["gamertag"])] = Uuid::fromString($row["uuid"])->getBytes();
+				$result[strtolower($row["gamertag"])] = Uuid::fromString($row["player_uuid"])->getBytes();
 			}
 			$callback($result);
 		});


### PR DESCRIPTION
This pull request makes significant improvements in the management of Death Inventory Log commands. Separate methods have been created for the "history," "restore," and "view" cases, enhancing code modularity and readability. Additionally, specific methods have been added for retrieving and applying logs to the player, as well as for displaying logs to the command sender. These changes aim to ease maintenance and future expansions of the code.

**Changes Made:**
- Refactoring of the main command logic (`onCommand`).
- Creation of specific methods for "restore" and "view" cases.
- Addition of methods for retrieving and applying logs to the player (`retrieveAndApplyLog`).
- Addition of a method for retrieving and displaying logs to the command sender (`retrieveAndDisplayLog`).
- Improvement in code reuse and overall clarity of Death Inventory Log-related code.

This pull request is ready for review. Comments and suggestions are appreciated.